### PR TITLE
date_parser in pd.read_ in data.py

### DIFF
--- a/fluxdataqaqc/data.py
+++ b/fluxdataqaqc/data.py
@@ -1114,7 +1114,6 @@ class Data(Plot, Convert):
             ix=[i for i, e in enumerate(self.header) if e in set(cols)]
             df = pd.read_excel(
                 self.climate_file,
-                parse_dates = [variables.get('date')],
                 usecols = ix,
                 engine = self.xl_parser,
                 **kwargs
@@ -1122,11 +1121,11 @@ class Data(Plot, Convert):
         else:
             df = pd.read_csv(
                 self.climate_file,
-                parse_dates = [variables.get('date')],
                 usecols = cols,
                 **kwargs
             )
-
+        df[variables.get('date')] = pd.to_datetime(df[variables.get('date')])
+        
         if 'missing_data_value' in dict(self.config.items('METADATA')):
             # force na_val because sometimes with read_excel it doesn't work...
             df[df == self.na_val] = np.nan


### PR DESCRIPTION
Attempts to address https://github.com/Open-ET/flux-data-qaqc/issues/32  where a future warning is thrown for the `parse_dates` argument in pd.read_csv

Switched to pd.to_datetime() after import instead.

May have to add a `errors='coerce'` argument in the [pd.to_datetime(](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.to_datetime.html)) function to address parsing errors in datetime data. 